### PR TITLE
Logging overridden site

### DIFF
--- a/Statsdash/report.py
+++ b/Statsdash/report.py
@@ -58,7 +58,18 @@ class Report(object):
         first_letter = self.frequency[0].upper()
         label = first_letter + "o" + first_letter
         return label
-    
+
+    def check_data_availability(self, override=False):
+        check = self.data.check_available_data()
+        if check["result"]:
+            return True
+        else:
+            logger.debug("Data not available for: %s" % check["site"])
+            if override:
+                self.warning_sites = check["site"]
+                return check["site"]
+            else:
+                return False	    
 
     def generate_html(self):
         """
@@ -137,7 +148,7 @@ class YoutubeReport(Report):
             if override:
                 self.warning_sites = check["channel"]
                 
-                return True
+                return check["site"]
             else:
                 return False
 		    
@@ -162,18 +173,6 @@ class AnalyticsCoreReport(Report):
             self.all_sites = False
         
         logger.debug("Running analytics core report")
-
-    def check_data_availability(self, override=False):
-        check = self.data.check_available_data()
-        if check["result"]:
-            return True
-        else:
-            logger.debug("Data not available for: %s" % check["site"])
-            if override:
-                self.warning_sites = check["site"]
-                return True
-            else:
-                return False
                 
                 
     def get_site(self):
@@ -316,18 +315,6 @@ class AnalyticsSocialReport(Report):
             self.all_sites = True
         else:
             self.all_sites = False
-		
-    def check_data_availability(self, override=False):
-        check = self.data.check_available_data()
-        if check["result"]:
-            return True
-        else:
-            logger.debug("Data not available for: %s" % check["site"])
-            if override:
-                self.warning_sites = check["site"]
-                return True
-            else:
-                return False	
                 
     def get_site(self):
         if len(self.sites) == 1:
@@ -417,19 +404,6 @@ class AnalyticsYearSocialReport(Report):
         subject = ' '.join([self.subject, dates])
         
         return subject
-
-		
-    def check_data_availability(self, override=False):
-        check = self.data.check_available_data()
-        if check["result"]:
-            return True
-        else:
-            logger.debug("Data not available for: %s" % check["site"])
-            if override:
-                self.warning_sites = check["site"]
-                return True
-            else:
-                return False	
                 
     def get_site(self):
         if len(self.sites) == 1:
@@ -508,20 +482,7 @@ class AnalyticsSocialExport(Report):
         self.warning_sites = []
         self.template = self.env.get_template("social.csv")
         
-        logger.debug("Running analytics social export")   	
-
-    def check_data_availability(self, override=False):
-        check = self.data.check_available_data()
-        if check["result"]:
-            return True
-        else:
-            logger.debug("Data not available for: %s" % check["site"])
-            if override:
-                self.warning_sites = check["site"]
-                return True
-            else:
-                return False	
-        
+        logger.debug("Running analytics social export")   	        
     	
     def generate_html(self):
 

--- a/Statsdash/report.py
+++ b/Statsdash/report.py
@@ -148,7 +148,7 @@ class YoutubeReport(Report):
             if override:
                 self.warning_sites = check["channel"]
                 
-                return check["site"]
+                return check["channel"]
             else:
                 return False
 		    

--- a/scheduler.py
+++ b/scheduler.py
@@ -181,8 +181,7 @@ def _run(dryrun=False):
                 data_available = True
                 no_data_site = report.check_data_availability(override=True)
                 logger.warning("Overriding data availability and sending report anyway")
-                error_list.add_error("No data available, overriding for report %s between %s - %s " % (identifier, period.start_date, period.end_date))
-                error_list.add_error("Overriding site %s " % no_data_site)
+                error_list.add_error("There is no data, or a lack of data available for the site: %s between %s - %s. This is being overridden to send the report %s anyway." % (no_data_site, period.start_date, period.end_date, identifier)))
             else:
                 data_available = report.check_data_availability()
             

--- a/scheduler.py
+++ b/scheduler.py
@@ -178,9 +178,11 @@ def _run(dryrun=False):
             period = utils.StatsRange.get_period(next_run_date, frequency)
             report = config["report"](config["sites"], period, config["recipients"], config["frequency"], config["subject"])  
             if run_logger.override_data == True:
-                data_available = report.check_data_availability(override=True)
+                data_available = True
+                no_data_site = report.check_data_availability(override=True)
                 logger.warning("Overriding data availability and sending report anyway")
                 error_list.add_error("No data available, overriding for report %s between %s - %s " % (identifier, period.start_date, period.end_date))
+                error_list.add_error("Overriding site %s " % no_data_site)
             else:
                 data_available = report.check_data_availability()
             


### PR DESCRIPTION
@currycoder  

If override is true, the data availability check function returns the site name(s) instead of True.
This can then be added to the error log to send out.