### PR TITLE
Fix to prevent some sites' reports sending early

### DIFF
--- a/Statsdash/GA/aggregate_data.py
+++ b/Statsdash/GA/aggregate_data.py
@@ -1,4 +1,3 @@
-
 import config
 import re
 import pygal
@@ -31,8 +30,22 @@ class AnalyticsData(object):
         self.site_ids = site_ids
     
     def check_available_data(self):
-        run_report = {"result":True, "site":[]}
+        run_report = {"result": True, "site": []}
         multiple_sites = True
+        # Get the end time of the period
+        period_end_time = datetime(
+            year=self.period.end_date.year,
+            month=self.period.end_date.month,
+            day=self.period.end_date.day,
+            hour=23,
+            minute=59,
+            second=59,
+        )
+        analytics_populated_time = period_end_time + timedelta(hours=1)
+        data_possibly_available = datetime.now() > analytics_populated_time
+        if not data_possibly_available:
+            print("Nah mate")
+            return False
         if len(self.sites) == 1:
             multiple_sites = False
         for site in self.sites:

--- a/Statsdash/GA/aggregate_data.py
+++ b/Statsdash/GA/aggregate_data.py
@@ -44,7 +44,6 @@ class AnalyticsData(object):
         analytics_populated_time = period_end_time + timedelta(hours=1)
         data_possibly_available = datetime.now() > analytics_populated_time
         if not data_possibly_available:
-            print("Nah mate")
             return False
         if len(self.sites) == 1:
             multiple_sites = False

--- a/Statsdash/GA/analytics.py
+++ b/Statsdash/GA/analytics.py
@@ -58,6 +58,7 @@ class Analytics(object):
         
     def data_available(self, site_id, stats_date):
         # TODO: Persist these results in a cache so we don't smash our rate limit
+
         query = self.ga.get(
             ids=site_id,
             start_date=stats_date,


### PR DESCRIPTION
Ensuring that reports can only send at 1AM the day after their end
period, at the earliest.

- [X] Is this Pull Request ready for review?

**Who would you like to review this pull request?**
@thomasjthomasj 

**What does this Pull Request do?**
Some statsdash reports are able to send a little after 23:00 on the report's target day, since in some cases google can provide analytics data immediately.  This breaks our 'is there data for each of the 24 hours?' check.

The change here introduces an additional sanity check for GA availability checks to ensure it is at least 01:00 on the day after the report's end day.   

**What are the relevant Github Issues or Zendesk tickets?**
Fixes #66 https://gntech.zendesk.com/inbox/conversations/740